### PR TITLE
Feature/ci

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,0 +1,17 @@
+name: ci-pull-request
+on:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+jobs:
+  unit_test:
+    runs-on: macos-latest
+    steps: 
+    - name: Checkout the code
+      uses: actions/checkout@v2
+    - name: Build
+      run: swift build -v
+    - name: Test
+      run: swift test --enable-code-coverage

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# This file provides an overview of code owners in this repository.
+
+# Each line is a file pattern followed by one or more owners.
+# The last matching pattern has the most precedence.
+# For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
+
+# These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
+* @corona-warn-app/cwa-app-ios-members


### PR DESCRIPTION
This PR adds the @corona-warn-app/cwa-app-ios-members as Codeowners and setups some basic CI via GitHub Actions 