### PR TITLE
chore: support common functions in test cases

### DIFF
--- a/Tests/jsonfunctionsTests/JsonFunctionsTestCases.swift
+++ b/Tests/jsonfunctionsTests/JsonFunctionsTestCases.swift
@@ -11,6 +11,7 @@ import AnyCodable
 struct JsonFunctionsTestCases: Decodable {
 
     let testCases: [JsonFunctionsTestCase]
+    let commonFunctions: [JsonFunctionDescriptor]?
 
 }
 

--- a/Tests/jsonfunctionsTests/JsonFunctionsTests.swift
+++ b/Tests/jsonfunctionsTests/JsonFunctionsTests.swift
@@ -10,14 +10,20 @@ import XCTest
 final class JsonFunctionsTests: XCTestCase {
 
     func testJsonFunctions() {
-        XCTAssertEqual(testCases.count, 779)
+        XCTAssertEqual(commonTestCases.testCases.count, 779)
 
         var passed = 0
         var failed = 0
         var throwsUnexpectedly = 0
 
-        for (index, testCase) in testCases.enumerated() {
+        for (index, testCase) in commonTestCases.testCases.enumerated() {
             let jsonFunctions = JsonFunctions()
+
+            if let commonFunctions = commonTestCases.commonFunctions {
+                commonFunctions.forEach {
+                    jsonFunctions.registerFunction(name: $0.name, definition: $0.definition)
+                }
+            }
 
             if let functions = testCase.functions {
                 functions.forEach {
@@ -66,9 +72,9 @@ final class JsonFunctionsTests: XCTestCase {
             }
         }
 
-        print("*** passed: \(passed)/\(testCases.count)")
-        print("*** failed: \(failed)/\(testCases.count)")
-        print("*** throwsUnexpectedly: \(throwsUnexpectedly)/\(testCases.count)")
+        print("*** passed: \(passed)/\(commonTestCases.testCases.count)")
+        print("*** failed: \(failed)/\(commonTestCases.testCases.count)")
+        print("*** throwsUnexpectedly: \(throwsUnexpectedly)/\(commonTestCases.testCases.count)")
     }
 
     func testDecodableReturnValue() throws {
@@ -133,14 +139,14 @@ final class JsonFunctionsTests: XCTestCase {
 
     // MARK: - Private
 
-    private lazy var testCases: [JsonFunctionsTestCase] = {
+    private lazy var commonTestCases: JsonFunctionsTestCases = {
         guard let urlJsonFile = Bundle.module.url(forResource: "jfn-common-test-cases", withExtension: "json"),
               let data = try? Data(contentsOf: urlJsonFile) else {
             fatalError("Failed init json file for tests - stop here")
         }
 
         do {
-            return try JSONDecoder().decode(JsonFunctionsTestCases.self, from: data).testCases
+            return try JSONDecoder().decode(JsonFunctionsTestCases.self, from: data)
         } catch let DecodingError.keyNotFound(jsonKey, context) {
             fatalError("missing key: \(jsonKey)\nDebug Description: \(context.debugDescription)")
         } catch let DecodingError.valueNotFound(type, context) {


### PR DESCRIPTION
if a file with shared test cases such as `jfn-common-test-cases.json` contains a top-level property `commonFunctions`, it is registered as functions to each test case in that file. This has the potentially to significantly reduce the file size of shared test cases.

This allows to reduce the file size of the CCL integration tests from [cwa-app-ccl](https://github.com/corona-warn-app/cwa-app-ccl) from >80M to ~6M and as a result, on my local machine, the test suite completes in ~5 instead of ~10 minutes.

For Android, see https://github.com/corona-warn-app/cwa-kotlin-jfn/pull/43